### PR TITLE
fix(zfspv): fixing data loss in case of pod deletion

### DIFF
--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -78,9 +78,8 @@ func UmountVolume(vol *apis.ZFSVolume, targetPath string,
 		}
 	}
 
-	if err := os.RemoveAll(targetPath); err != nil {
+	if err := os.Remove(targetPath); err != nil {
 		logrus.Errorf("zfspv: failed to remove mount path Error: %v", err)
-		return err
 	}
 
 	logrus.Infof("umount done path %v", targetPath)


### PR DESCRIPTION
looks like a bug in ZFS as when you change the mountpoint property to none,
ZFS automatically umounts the file system. When we delete the pod, we get the
unmount request for the old pod and mount request for the new pod. Unmount
is done by the driver by setting mountpoint to none and the driver assumes that
unmount has done and proceeded to delete the mountpath, but here zfs has not unmounted
the dataset

```
$ sudo zfs get all zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765 | grep mount
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  mounted               yes                                                                                                -
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  mountpoint            none                                                                                               local
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  canmount              on
```

here, the driver will assume that dataset has been unmouted and proceed to delete the
mountpath and it will delete the data as part of cleaning up for the NodeUnPublish request.

Shifting to use zfs umount instead of doing zfs set mountpoint=none for umounting the dataset.
Also the driver is using os.RemoveAll which is very risky as it will clean
child also, since the mountpoint is not supposed to have anything,
just os.Remove is sufficient and it will fail if there is anything there.

Signed-off-by: Pawan <pawan@mayadata.io>